### PR TITLE
Modified gitignore for RVM and rbenv material

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.box
 .*.swp
+.ruby-version
+.rbenv-gemsets

--- a/.ruby-version
+++ b/.ruby-version
@@ -1,1 +1,0 @@
-ruby-1.9.3-p362@puppet-vagrant-boxes


### PR DESCRIPTION
Simply adds rbenv and rvm files to .gitignore, and removes the existing .ruby-version file, which confuses rbenv.
