### PR TITLE
Add Scientific Linux 6.4 x64 boxes for virtual box

### DIFF
--- a/definitions/scientific-64-x64-vb4210-nocm/base.sh
+++ b/definitions/scientific-64-x64-vb4210-nocm/base.sh
@@ -1,0 +1,14 @@
+# Base install
+
+sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
+
+cat > /etc/yum.repos.d/epel.repo << EOM
+[epel]
+name=epel
+baseurl=https://download.fedoraproject.org/pub/epel/6/\$basearch
+enabled=1
+gpgcheck=0
+EOM
+
+yum -y install gcc make gcc-c++ kernel-devel-`uname -r` zlib-devel openssl-devel readline-devel sqlite-devel perl wget dkms
+

--- a/definitions/scientific-64-x64-vb4210-nocm/cfengine.sh
+++ b/definitions/scientific-64-x64-vb4210-nocm/cfengine.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Lets not install untrusted packages to manage our infrastructure
+Trusted_GPG_Fingerprint="EF49F970C3D4AEF5E557FB6D8D5A7684F97E94BE"
+GPGURL="http://cfengine.com/pub/gpg.key"
+GPGKEY="/tmp/cfengine_gpg.key"
+YUMREPO="http://cfengine.com/pub/yum"
+
+
+
+function main
+{
+    configure_repo
+    retrieve_GPGKEY
+    validate_GPGKEY
+    install_GPGKEY
+    install_cfengine
+}
+
+function configure_repo
+{
+    # Install Yum Client Repository Definition
+    cat > /etc/yum.repos.d/cfengine.repo << EOM && return 0 || return 1
+[cfengine]
+name=cfengine
+baseurl=$YUMREPO
+enabled=1
+gpgcheck=1
+EOM
+}
+
+function retrieve_GPGKEY
+{
+    # Retrieve, validate, and install GPGKEY
+    curl --silent --output $GPGKEY $GPGURL
+    Found_GPG_Fingerprint=$(gpg --quiet --with-fingerprint $GPGKEY | grep fingerprint | cut -d "=" -f2 | sed 's/ //g')
+}
+
+function validate_GPGKEY
+{
+    if [ "$Found_GPG_Fingerprint" = "$Trusted_GPG_Fingerprint" ]; then
+        echo "Trusting Retrieved Key: $GPGURL"
+        return 0
+    else
+        return 1
+    fi
+}
+
+function install_GPGKEY
+{
+    # We want to avoid possibly importing keys unnecissarily if they are already installed
+    keyid=$(echo $(gpg --throw-keyids < $GPGKEY) | cut --characters=11-18 | tr [A-Z] [a-z])
+    if ! rpm -q gpg-pubkey-$keyid > /dev/null 2>&1 ; then
+        echo "Installing GPG public key with ID $keyid from $GPGKEY..."
+        rpm --import $GPGKEY && return 0 || return 1
+    else 
+        # Found key already installed
+        return 0
+    fi
+}
+
+function install_cfengine
+{
+    yum -y install cfengine-community && return 0 || return 1
+}
+
+main
+
+

--- a/definitions/scientific-64-x64-vb4210-nocm/chef.sh
+++ b/definitions/scientific-64-x64-vb4210-nocm/chef.sh
@@ -1,0 +1,3 @@
+# Install Chef
+gem install --no-ri --no-rdoc chef
+

--- a/definitions/scientific-64-x64-vb4210-nocm/cleanup.sh
+++ b/definitions/scientific-64-x64-vb4210-nocm/cleanup.sh
@@ -1,0 +1,6 @@
+yum -y erase gtk2 libX11 hicolor-icon-theme avahi freetype bitstream-vera-fonts
+yum -y clean all
+rm -rf /etc/yum.repos.d/{puppetlabs,epel}.repo
+rm -rf VBoxGuestAdditions_*.iso
+sed -i /HWADDR/d /etc/sysconfig/network-scripts/ifcfg-eth0
+rm /etc/udev/rules.d/70-persistent-net.rules

--- a/definitions/scientific-64-x64-vb4210-nocm/definition.rb
+++ b/definitions/scientific-64-x64-vb4210-nocm/definition.rb
@@ -1,0 +1,37 @@
+Veewee::Session.declare({
+  :cpu_count => '1',
+  :memory_size=> '480',
+  :disk_size => '10140',
+  :disk_format => 'VDI',
+  :hostiocache => 'off',
+  :os_type_id => 'RedHat_64',
+  :iso_file => "SL-64-x86_64-2013-03-18-boot.iso",
+  :iso_src => "http://www.mirrorservice.org/sites/ftp.scientificlinux.org/linux/scientific/6.4/x86_64/iso/SL-64-x86_64-2013-03-18-boot.iso",
+  :iso_md5 => "e9625e2c3b4b02d94ffa478773d5d58f",
+  :iso_download_timeout => 1000,
+  :boot_wait => "15",
+  :boot_cmd_sequence => [
+    '<Tab> text ks=http://%IP%:%PORT%/ks.cfg<Enter>'
+  ],
+  :kickstart_port => "7122",
+  :kickstart_timeout => 10000,
+  :kickstart_file => "ks.cfg",
+  :ssh_login_timeout => "10000",
+  :ssh_user => "veewee",
+  :ssh_password => "veewee",
+  :ssh_key => "",
+  :ssh_host_port => "7222",
+  :ssh_guest_port => "22",
+  :sudo_cmd => "echo '%p'|sudo -S sh '%f'",
+  :shutdown_cmd => "/sbin/halt -h -p",
+  :postinstall_files => [
+    "base.sh",
+    "vagrant.sh",
+    "virtualbox.sh",
+    #"kvm.sh",
+    #"vmfusion.sh",
+    "cleanup.sh",
+    "zerodisk.sh"
+  ],
+  :postinstall_timeout => 10000
+})

--- a/definitions/scientific-64-x64-vb4210-nocm/ks.cfg
+++ b/definitions/scientific-64-x64-vb4210-nocm/ks.cfg
@@ -1,0 +1,41 @@
+install
+url --url=http://www.mirrorservice.org/sites/ftp.scientificlinux.org/linux/scientific/6.4/x86_64/os/
+lang en_US.UTF-8
+keyboard us
+network --bootproto=dhcp
+rootpw --iscrypted $1$damlkd,f$UC/u5pUts5QiU3ow.CSso/
+firewall --enabled --service=ssh
+authconfig --enableshadow --passalgo=sha512
+selinux --disabled
+timezone UTC
+bootloader --location=mbr
+
+text
+skipx
+zerombr
+
+clearpart --all --initlabel
+autopart
+
+auth  --useshadow  --enablemd5
+firstboot --disabled
+reboot
+
+%packages --ignoremissing
+@core
+bzip2
+kernel-devel
+kernel-headers
+-ipw2100-firmware
+-ipw2200-firmware
+-ivtv-firmware
+%end
+
+%post
+/usr/bin/yum -y install sudo
+/usr/sbin/groupadd veewee
+/usr/sbin/useradd veewee -g veewee -G wheel
+echo "veewee"|passwd --stdin veewee
+echo "veewee        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/veewee
+chmod 0440 /etc/sudoers.d/veewee
+%end

--- a/definitions/scientific-64-x64-vb4210-nocm/puppet.sh
+++ b/definitions/scientific-64-x64-vb4210-nocm/puppet.sh
@@ -1,0 +1,12 @@
+# Install Puppet
+
+cat > /etc/yum.repos.d/puppetlabs.repo << EOM
+[puppetlabs]
+name=puppetlabs
+baseurl=http://yum.puppetlabs.com/el/6/products/\$basearch
+enabled=1
+gpgcheck=0
+EOM
+
+yum -y install puppet facter
+

--- a/definitions/scientific-64-x64-vb4210-nocm/ruby.sh
+++ b/definitions/scientific-64-x64-vb4210-nocm/ruby.sh
@@ -1,0 +1,3 @@
+# Install Ruby
+yum -y install ruby ruby-devel rubygems
+

--- a/definitions/scientific-64-x64-vb4210-nocm/vagrant.sh
+++ b/definitions/scientific-64-x64-vb4210-nocm/vagrant.sh
@@ -1,0 +1,18 @@
+# Vagrant specific
+date > /etc/vagrant_box_build_time
+
+# Add vagrant user
+/usr/sbin/groupadd vagrant
+/usr/sbin/useradd vagrant -g vagrant -G wheel
+echo "vagrant"|passwd --stdin vagrant
+echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
+chmod 0440 /etc/sudoers.d/vagrant
+
+# Installing vagrant keys
+mkdir -pm 700 /home/vagrant/.ssh
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O /home/vagrant/.ssh/authorized_keys
+chmod 0600 /home/vagrant/.ssh/authorized_keys
+chown -R vagrant /home/vagrant/.ssh
+
+# Customize the message of the day
+echo 'Welcome to your Vagrant-built virtual machine.' > /etc/motd

--- a/definitions/scientific-64-x64-vb4210-nocm/virtualbox.sh
+++ b/definitions/scientific-64-x64-vb4210-nocm/virtualbox.sh
@@ -1,0 +1,8 @@
+# Installing the virtualbox guest additions
+VBOX_VERSION=$(cat /home/veewee/.vbox_version)
+cd /tmp
+mount -o loop /home/veewee/VBoxGuestAdditions_$VBOX_VERSION.iso /mnt
+sh /mnt/VBoxLinuxAdditions.run
+umount /mnt
+rm -rf /home/veewee/VBoxGuestAdditions_*.iso
+

--- a/definitions/scientific-64-x64-vb4210-nocm/zerodisk.sh
+++ b/definitions/scientific-64-x64-vb4210-nocm/zerodisk.sh
@@ -1,0 +1,3 @@
+# Zero out the free space to save space in the final image:
+dd if=/dev/zero of=/EMPTY bs=1M
+rm -f /EMPTY

--- a/definitions/scientific-64-x64-vb4210/base.sh
+++ b/definitions/scientific-64-x64-vb4210/base.sh
@@ -1,0 +1,14 @@
+# Base install
+
+sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
+
+cat > /etc/yum.repos.d/epel.repo << EOM
+[epel]
+name=epel
+baseurl=https://download.fedoraproject.org/pub/epel/6/\$basearch
+enabled=1
+gpgcheck=0
+EOM
+
+yum -y install gcc make gcc-c++ kernel-devel-`uname -r` zlib-devel openssl-devel readline-devel sqlite-devel perl wget dkms
+

--- a/definitions/scientific-64-x64-vb4210/cfengine.sh
+++ b/definitions/scientific-64-x64-vb4210/cfengine.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Lets not install untrusted packages to manage our infrastructure
+Trusted_GPG_Fingerprint="EF49F970C3D4AEF5E557FB6D8D5A7684F97E94BE"
+GPGURL="http://cfengine.com/pub/gpg.key"
+GPGKEY="/tmp/cfengine_gpg.key"
+YUMREPO="http://cfengine.com/pub/yum"
+
+
+
+function main
+{
+    configure_repo
+    retrieve_GPGKEY
+    validate_GPGKEY
+    install_GPGKEY
+    install_cfengine
+}
+
+function configure_repo
+{
+    # Install Yum Client Repository Definition
+    cat > /etc/yum.repos.d/cfengine.repo << EOM && return 0 || return 1
+[cfengine]
+name=cfengine
+baseurl=$YUMREPO
+enabled=1
+gpgcheck=1
+EOM
+}
+
+function retrieve_GPGKEY
+{
+    # Retrieve, validate, and install GPGKEY
+    curl --silent --output $GPGKEY $GPGURL
+    Found_GPG_Fingerprint=$(gpg --quiet --with-fingerprint $GPGKEY | grep fingerprint | cut -d "=" -f2 | sed 's/ //g')
+}
+
+function validate_GPGKEY
+{
+    if [ "$Found_GPG_Fingerprint" = "$Trusted_GPG_Fingerprint" ]; then
+        echo "Trusting Retrieved Key: $GPGURL"
+        return 0
+    else
+        return 1
+    fi
+}
+
+function install_GPGKEY
+{
+    # We want to avoid possibly importing keys unnecissarily if they are already installed
+    keyid=$(echo $(gpg --throw-keyids < $GPGKEY) | cut --characters=11-18 | tr [A-Z] [a-z])
+    if ! rpm -q gpg-pubkey-$keyid > /dev/null 2>&1 ; then
+        echo "Installing GPG public key with ID $keyid from $GPGKEY..."
+        rpm --import $GPGKEY && return 0 || return 1
+    else 
+        # Found key already installed
+        return 0
+    fi
+}
+
+function install_cfengine
+{
+    yum -y install cfengine-community && return 0 || return 1
+}
+
+main
+
+

--- a/definitions/scientific-64-x64-vb4210/chef.sh
+++ b/definitions/scientific-64-x64-vb4210/chef.sh
@@ -1,0 +1,3 @@
+# Install Chef
+gem install --no-ri --no-rdoc chef
+

--- a/definitions/scientific-64-x64-vb4210/cleanup.sh
+++ b/definitions/scientific-64-x64-vb4210/cleanup.sh
@@ -1,0 +1,6 @@
+yum -y erase gtk2 libX11 hicolor-icon-theme avahi freetype bitstream-vera-fonts
+yum -y clean all
+rm -rf /etc/yum.repos.d/{puppetlabs,epel}.repo
+rm -rf VBoxGuestAdditions_*.iso
+sed -i /HWADDR/d /etc/sysconfig/network-scripts/ifcfg-eth0
+rm /etc/udev/rules.d/70-persistent-net.rules

--- a/definitions/scientific-64-x64-vb4210/definition.rb
+++ b/definitions/scientific-64-x64-vb4210/definition.rb
@@ -1,0 +1,40 @@
+Veewee::Session.declare({
+  :cpu_count => '1',
+  :memory_size=> '480',
+  :disk_size => '10140',
+  :disk_format => 'VDI',
+  :hostiocache => 'off',
+  :os_type_id => 'RedHat_64',
+  :iso_file => "SL-64-x86_64-2013-03-18-boot.iso",
+  :iso_src => "http://www.mirrorservice.org/sites/ftp.scientificlinux.org/linux/scientific/6.4/x86_64/iso/SL-64-x86_64-2013-03-18-boot.iso",
+  :iso_md5 => "e9625e2c3b4b02d94ffa478773d5d58f",
+  :iso_download_timeout => 1000,
+  :boot_wait => "15",
+  :boot_cmd_sequence => [
+    '<Tab> text ks=http://%IP%:%PORT%/ks.cfg<Enter>'
+  ],
+  :kickstart_port => "7122",
+  :kickstart_timeout => 10000,
+  :kickstart_file => "ks.cfg",
+  :ssh_login_timeout => "10000",
+  :ssh_user => "veewee",
+  :ssh_password => "veewee",
+  :ssh_key => "",
+  :ssh_host_port => "7222",
+  :ssh_guest_port => "22",
+  :sudo_cmd => "echo '%p'|sudo -S sh '%f'",
+  :shutdown_cmd => "/sbin/halt -h -p",
+  :postinstall_files => [
+    "base.sh",
+    "ruby.sh",
+    "chef.sh",
+    "puppet.sh",
+    "vagrant.sh",
+    "virtualbox.sh",
+    #"kvm.sh",
+    #"vmfusion.sh",
+    "cleanup.sh",
+    "zerodisk.sh"
+  ],
+  :postinstall_timeout => 10000
+})

--- a/definitions/scientific-64-x64-vb4210/ks.cfg
+++ b/definitions/scientific-64-x64-vb4210/ks.cfg
@@ -1,0 +1,41 @@
+install
+url --url=http://www.mirrorservice.org/sites/ftp.scientificlinux.org/linux/scientific/6.4/x86_64/os/
+lang en_US.UTF-8
+keyboard us
+network --bootproto=dhcp
+rootpw --iscrypted $1$damlkd,f$UC/u5pUts5QiU3ow.CSso/
+firewall --enabled --service=ssh
+authconfig --enableshadow --passalgo=sha512
+selinux --disabled
+timezone UTC
+bootloader --location=mbr
+
+text
+skipx
+zerombr
+
+clearpart --all --initlabel
+autopart
+
+auth  --useshadow  --enablemd5
+firstboot --disabled
+reboot
+
+%packages --ignoremissing
+@core
+bzip2
+kernel-devel
+kernel-headers
+-ipw2100-firmware
+-ipw2200-firmware
+-ivtv-firmware
+%end
+
+%post
+/usr/bin/yum -y install sudo
+/usr/sbin/groupadd veewee
+/usr/sbin/useradd veewee -g veewee -G wheel
+echo "veewee"|passwd --stdin veewee
+echo "veewee        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/veewee
+chmod 0440 /etc/sudoers.d/veewee
+%end

--- a/definitions/scientific-64-x64-vb4210/puppet.sh
+++ b/definitions/scientific-64-x64-vb4210/puppet.sh
@@ -1,0 +1,12 @@
+# Install Puppet
+
+cat > /etc/yum.repos.d/puppetlabs.repo << EOM
+[puppetlabs]
+name=puppetlabs
+baseurl=http://yum.puppetlabs.com/el/6/products/\$basearch
+enabled=1
+gpgcheck=0
+EOM
+
+yum -y install puppet facter
+

--- a/definitions/scientific-64-x64-vb4210/ruby.sh
+++ b/definitions/scientific-64-x64-vb4210/ruby.sh
@@ -1,0 +1,3 @@
+# Install Ruby
+yum -y install ruby ruby-devel rubygems
+

--- a/definitions/scientific-64-x64-vb4210/vagrant.sh
+++ b/definitions/scientific-64-x64-vb4210/vagrant.sh
@@ -1,0 +1,18 @@
+# Vagrant specific
+date > /etc/vagrant_box_build_time
+
+# Add vagrant user
+/usr/sbin/groupadd vagrant
+/usr/sbin/useradd vagrant -g vagrant -G wheel
+echo "vagrant"|passwd --stdin vagrant
+echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
+chmod 0440 /etc/sudoers.d/vagrant
+
+# Installing vagrant keys
+mkdir -pm 700 /home/vagrant/.ssh
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O /home/vagrant/.ssh/authorized_keys
+chmod 0600 /home/vagrant/.ssh/authorized_keys
+chown -R vagrant /home/vagrant/.ssh
+
+# Customize the message of the day
+echo 'Welcome to your Vagrant-built virtual machine.' > /etc/motd

--- a/definitions/scientific-64-x64-vb4210/virtualbox.sh
+++ b/definitions/scientific-64-x64-vb4210/virtualbox.sh
@@ -1,0 +1,8 @@
+# Installing the virtualbox guest additions
+VBOX_VERSION=$(cat /home/veewee/.vbox_version)
+cd /tmp
+mount -o loop /home/veewee/VBoxGuestAdditions_$VBOX_VERSION.iso /mnt
+sh /mnt/VBoxLinuxAdditions.run
+umount /mnt
+rm -rf /home/veewee/VBoxGuestAdditions_*.iso
+

--- a/definitions/scientific-64-x64-vb4210/zerodisk.sh
+++ b/definitions/scientific-64-x64-vb4210/zerodisk.sh
@@ -1,0 +1,3 @@
+# Zero out the free space to save space in the final image:
+dd if=/dev/zero of=/EMPTY bs=1M
+rm -f /EMPTY

--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -43,6 +43,21 @@ Vagrant.configure("2") do |config|
   end
 
   ##################
+  # Scientific 6.4 #
+  ##################
+  config.vm.define "scientific-64-x64-vb4210" do |v|
+    v.vm.box = "scientific-64-x64-vb4210"
+    v.vm.hostname = "scientific-64-x64-vb4210.vm"
+    v.vm.box_url = "http://puppet-vagrant-boxes.puppetlabs.com/scientific-64-x64-vb4210.box"
+  end
+
+  config.vm.define "scientific-64-x64-vb4210-nocm" do |v|
+    v.vm.box = "scientific-64-x64-vb4210-nocm"
+    v.vm.hostname = "scientific-64-x64-vb4210-nocm.vm"
+    v.vm.box_url = "http://puppet-vagrant-boxes.puppetlabs.com/scientific-64-x64-vb4210-nocm.box"
+  end
+
+  ##################
   # Debian 6.0.7   #
   ##################
   config.vm.define "debian-607-x64-vbox4210" do |v|

--- a/html/index.html
+++ b/html/index.html
@@ -78,6 +78,14 @@
               <td><a href="centos-59-x64-vbox4210-nocm.box">nocm</a></td>
             </tr>
             <tr>
+              <td>Scientific</td>
+              <td>6.4</td>
+              <td>x64</td>
+              <td>Virtualbox 4.2.10</td>
+              <td><a href="scientific-64-x64-vb4210.box">plain</a></td>
+              <td><a href="scientific-64-x64-vb4210-nocm.box">nocm</a></td>
+            </tr>
+            <tr>
               <td>Debian</td>
               <td>6.0.7</td>
               <td>x64</td>


### PR DESCRIPTION
I do not know what the procedure is to get my vbox files into S3, so I've put them on a public web server I manage.  They will be temporarily available at http://vagrant.tamu.edu.

The "nocm" box is currently being used and tested successfully using my [puppet-zfsonlinux](https://github.com/treydock/puppet-zfsonlinux) module.

Once I get a copy of Fusion I can build those also.

Basing the 'nocm' version off the CentOS 6.4 x64 nocm, I was unable to make "validate" pass the ruby and gem checks.  I assume this is expected, and was unable to find documented methods for skipping those validations unless I use the 2nd example below.

```
$ veewee vbox validate scientific-64-x64-vb4210-nocm --tags=vagrant virtualbox
Checking user - OK
Checking sudo - OK
Checking ruby - FAILED
Command: . /etc/profile ;ruby --version 2> /dev/null 1> /dev/null;  echo $?
Expected string 0
Output:
Checking gem - FAILED
Command: . /etc/profile ;gem --version 2> /dev/null 1> /dev/null;  echo $?
Expected string 0
Output:
Checking shared folder - OK
```

```
$ veewee vbox validate scientific-64-x64-vb4210-nocm --tags=vagrant
Checking shared folder - OK
```
