### PR TITLE
Update yum sources for CentOS 6.x

### DIFF
--- a/definitions/centos-63-x64/puppet.sh
+++ b/definitions/centos-63-x64/puppet.sh
@@ -6,6 +6,12 @@ name=puppetlabs
 baseurl=http://yum.puppetlabs.com/el/6/products/\$basearch
 enabled=1
 gpgcheck=0
+
+[puppetlabs-dependencies]
+name=puppetlabdsdependencies
+baseurl=http://yum.puppetlabs.com/el/6/dependencies/\$basearch
+enabled=1
+gpgcheck=0
 EOM
 
 yum -y install puppet facter

--- a/definitions/centos-64-x64-fusion503-nocm/puppet.sh
+++ b/definitions/centos-64-x64-fusion503-nocm/puppet.sh
@@ -6,6 +6,12 @@ name=puppetlabs
 baseurl=http://yum.puppetlabs.com/el/6/products/\$basearch
 enabled=1
 gpgcheck=0
+
+[puppetlabs-dependencies]
+name=puppetlabdsdependencies
+baseurl=http://yum.puppetlabs.com/el/6/dependencies/\$basearch
+enabled=1
+gpgcheck=0
 EOM
 
 yum -y install puppet facter

--- a/definitions/centos-64-x64-fusion503/puppet.sh
+++ b/definitions/centos-64-x64-fusion503/puppet.sh
@@ -6,6 +6,12 @@ name=puppetlabs
 baseurl=http://yum.puppetlabs.com/el/6/products/\$basearch
 enabled=1
 gpgcheck=0
+
+[puppetlabs-dependencies]
+name=puppetlabdsdependencies
+baseurl=http://yum.puppetlabs.com/el/6/dependencies/\$basearch
+enabled=1
+gpgcheck=0
 EOM
 
 yum -y install puppet facter

--- a/definitions/centos-64-x64-vbox4210-nocm/puppet.sh
+++ b/definitions/centos-64-x64-vbox4210-nocm/puppet.sh
@@ -6,6 +6,12 @@ name=puppetlabs
 baseurl=http://yum.puppetlabs.com/el/6/products/\$basearch
 enabled=1
 gpgcheck=0
+
+[puppetlabs-dependencies]
+name=puppetlabdsdependencies
+baseurl=http://yum.puppetlabs.com/el/6/dependencies/\$basearch
+enabled=1
+gpgcheck=0
 EOM
 
 yum -y install puppet facter

--- a/definitions/centos-64-x64-vbox4210/puppet.sh
+++ b/definitions/centos-64-x64-vbox4210/puppet.sh
@@ -6,6 +6,12 @@ name=puppetlabs
 baseurl=http://yum.puppetlabs.com/el/6/products/\$basearch
 enabled=1
 gpgcheck=0
+
+[puppetlabs-dependencies]
+name=puppetlabdsdependencies
+baseurl=http://yum.puppetlabs.com/el/6/dependencies/\$basearch
+enabled=1
+gpgcheck=0
 EOM
 
 yum -y install puppet facter


### PR DESCRIPTION
The ruby-rgen package has moved from http://yum.puppetlabs.com/el/6/products to http://yum.puppetlabs.com/el/6/dependencies. The result of this is that the installation of puppet fails when it cannot locate ruby-rgen.

This PR fixes the issue by adding the new repository to Yum for the affected CentOS 6.x definitions.
