### PR TITLE
Increase disk_size from 10GB to 80GB to match files.vagrantup.com boxes

### DIFF
--- a/definitions/centos-58-x64/definition.rb
+++ b/definitions/centos-58-x64/definition.rb
@@ -1,6 +1,6 @@
 Veewee::Session.declare({
   :cpu_count => '1', :memory_size=> '384',
-  :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off', :ioapic => 'on', :pae => 'on',
+  :disk_size => '81920', :disk_format => 'VDI', :hostiocache => 'off', :ioapic => 'on', :pae => 'on',
   :os_type_id => 'RedHat_64',
   :iso_file => "CentOS-5.8-x86_64-netinstall.iso",
   :iso_src => "http://mirrors.arsc.edu/centos/5.8/isos/x86_64/CentOS-5.8-x86_64-netinstall.iso",

--- a/definitions/centos-59-x64-vbox4210-nocm/definition.rb
+++ b/definitions/centos-59-x64-vbox4210-nocm/definition.rb
@@ -1,6 +1,6 @@
 Veewee::Session.declare({
   :cpu_count => '1', :memory_size=> '384',
-  :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off', :ioapic => 'on', :pae => 'on',
+  :disk_size => '81920', :disk_format => 'VDI', :hostiocache => 'off', :ioapic => 'on', :pae => 'on',
   :os_type_id => 'RedHat_64',
   :iso_file => "CentOS-5.9-x86_64-netinstall.iso",
   :iso_src => "http://mirrors.kernel.org/centos/5.9/isos/x86_64/CentOS-5.9-x86_64-netinstall.iso",

--- a/definitions/centos-59-x64-vbox4210/definition.rb
+++ b/definitions/centos-59-x64-vbox4210/definition.rb
@@ -1,6 +1,6 @@
 Veewee::Session.declare({
   :cpu_count => '1', :memory_size=> '384',
-  :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off', :ioapic => 'on', :pae => 'on',
+  :disk_size => '81920', :disk_format => 'VDI', :hostiocache => 'off', :ioapic => 'on', :pae => 'on',
   :os_type_id => 'RedHat_64',
   :iso_file => "CentOS-5.9-x86_64-netinstall.iso",
   :iso_src => "http://mirrors.kernel.org/centos/5.9/isos/x86_64/CentOS-5.9-x86_64-netinstall.iso",

--- a/definitions/centos-63-x64/definition.rb
+++ b/definitions/centos-63-x64/definition.rb
@@ -1,7 +1,7 @@
 Veewee::Session.declare({
   :cpu_count => '1',
   :memory_size=> '480',
-  :disk_size => '10140',
+  :disk_size => '81920',
   :disk_format => 'VDI',
   :hostiocache => 'off',
   :os_type_id => 'RedHat_64',

--- a/definitions/centos-64-x64-fusion503-nocm/definition.rb
+++ b/definitions/centos-64-x64-fusion503-nocm/definition.rb
@@ -1,7 +1,7 @@
 Veewee::Session.declare({
   :cpu_count => '1',
   :memory_size=> '480',
-  :disk_size => '10140',
+  :disk_size => '81920',
   :disk_format => 'VDI',
   :hostiocache => 'off',
   :os_type_id => 'RedHat',

--- a/definitions/centos-64-x64-fusion503/definition.rb
+++ b/definitions/centos-64-x64-fusion503/definition.rb
@@ -1,7 +1,7 @@
 Veewee::Session.declare({
   :cpu_count => '1',
   :memory_size=> '480',
-  :disk_size => '10140',
+  :disk_size => '81920',
   :disk_format => 'VDI',
   :hostiocache => 'off',
   :os_type_id => 'RedHat',

--- a/definitions/centos-64-x64-vbox4210-nocm/definition.rb
+++ b/definitions/centos-64-x64-vbox4210-nocm/definition.rb
@@ -1,7 +1,7 @@
 Veewee::Session.declare({
   :cpu_count => '1',
   :memory_size=> '480',
-  :disk_size => '10140',
+  :disk_size => '81920',
   :disk_format => 'VDI',
   :hostiocache => 'off',
   :os_type_id => 'RedHat_64',

--- a/definitions/centos-64-x64-vbox4210/definition.rb
+++ b/definitions/centos-64-x64-vbox4210/definition.rb
@@ -1,7 +1,7 @@
 Veewee::Session.declare({
   :cpu_count => '1',
   :memory_size=> '480',
-  :disk_size => '10140',
+  :disk_size => '81920',
   :disk_format => 'VDI',
   :hostiocache => 'off',
   :os_type_id => 'RedHat_64',

--- a/definitions/debian-606-x64/definition.rb
+++ b/definitions/debian-606-x64/definition.rb
@@ -1,7 +1,7 @@
 Veewee::Definition.declare({
   :cpu_count => '1',
   :memory_size=> '256',
-  :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off',
+  :disk_size => '81920', :disk_format => 'VDI', :hostiocache => 'off',
   :os_type_id => 'Debian_64',
   :iso_file => "debian-6.0.6-amd64-netinst.iso",
   :iso_src => "http://cdimage.debian.org/debian-cd/6.0.6/amd64/iso-cd/debian-6.0.6-amd64-netinst.iso",

--- a/definitions/debian-607-x64-vbox4210-nocm/definition.rb
+++ b/definitions/debian-607-x64-vbox4210-nocm/definition.rb
@@ -1,7 +1,7 @@
 Veewee::Definition.declare({
   :cpu_count => '1',
   :memory_size=> '256',
-  :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off',
+  :disk_size => '81920', :disk_format => 'VDI', :hostiocache => 'off',
   :os_type_id => 'Debian_64',
   :iso_file => "debian-6.0.7-amd64-netinst.iso",
   :iso_src => "http://cdimage.debian.org/debian-cd/6.0.7/amd64/iso-cd/debian-6.0.7-amd64-netinst.iso",

--- a/definitions/debian-607-x64-vbox4210/definition.rb
+++ b/definitions/debian-607-x64-vbox4210/definition.rb
@@ -1,7 +1,7 @@
 Veewee::Definition.declare({
   :cpu_count => '1',
   :memory_size=> '256',
-  :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off',
+  :disk_size => '81920', :disk_format => 'VDI', :hostiocache => 'off',
   :os_type_id => 'Debian_64',
   :iso_file => "debian-6.0.7-amd64-netinst.iso",
   :iso_src => "http://cdimage.debian.org/debian-cd/6.0.7/amd64/iso-cd/debian-6.0.7-amd64-netinst.iso",

--- a/definitions/debian-607-x64-vf503-nocm/definition.rb
+++ b/definitions/debian-607-x64-vf503-nocm/definition.rb
@@ -1,7 +1,7 @@
 Veewee::Definition.declare({
   :cpu_count => '1',
   :memory_size=> '256',
-  :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off',
+  :disk_size => '81920', :disk_format => 'VDI', :hostiocache => 'off',
   :os_type_id => 'Debian_64',
   :iso_file => "debian-6.0.7-amd64-netinst.iso",
   :iso_src => "http://cdimage.debian.org/debian-cd/6.0.7/amd64/iso-cd/debian-6.0.7-amd64-netinst.iso",

--- a/definitions/debian-607-x64-vf503/definition.rb
+++ b/definitions/debian-607-x64-vf503/definition.rb
@@ -1,7 +1,7 @@
 Veewee::Definition.declare({
   :cpu_count => '1',
   :memory_size=> '256',
-  :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off',
+  :disk_size => '81920', :disk_format => 'VDI', :hostiocache => 'off',
   :os_type_id => 'Debian_64',
   :iso_file => "debian-6.0.7-amd64-netinst.iso",
   :iso_src => "http://cdimage.debian.org/debian-cd/6.0.7/amd64/iso-cd/debian-6.0.7-amd64-netinst.iso",

--- a/definitions/debian-70rc1-x64-vbox4210-nocm/definition.rb
+++ b/definitions/debian-70rc1-x64-vbox4210-nocm/definition.rb
@@ -3,7 +3,7 @@
 Veewee::Definition.declare({
   :cpu_count => '1',
   :memory_size=> '256',
-  :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off',
+  :disk_size => '81920', :disk_format => 'VDI', :hostiocache => 'off',
   :os_type_id => 'Debian_64',
   :iso_file => "debian-wheezy-DI-rc1-amd64-netinst.iso",
   :iso_src => "http://cdimage.debian.org/cdimage/wheezy_di_rc1/amd64/iso-cd/debian-wheezy-DI-rc1-amd64-netinst.iso",

--- a/definitions/debian-70rc1-x64-vbox4210/definition.rb
+++ b/definitions/debian-70rc1-x64-vbox4210/definition.rb
@@ -3,7 +3,7 @@
 Veewee::Definition.declare({
   :cpu_count => '1',
   :memory_size=> '256',
-  :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off',
+  :disk_size => '81920', :disk_format => 'VDI', :hostiocache => 'off',
   :os_type_id => 'Debian_64',
   :iso_file => "debian-wheezy-DI-rc1-amd64-netinst.iso",
   :iso_src => "http://cdimage.debian.org/cdimage/wheezy_di_rc1/amd64/iso-cd/debian-wheezy-DI-rc1-amd64-netinst.iso",

--- a/definitions/debian-70rc1-x64-vf503-nocm/definition.rb
+++ b/definitions/debian-70rc1-x64-vf503-nocm/definition.rb
@@ -3,7 +3,7 @@
 Veewee::Definition.declare({
   :cpu_count => '1',
   :memory_size=> '256',
-  :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off',
+  :disk_size => '81920', :disk_format => 'VDI', :hostiocache => 'off',
   :os_type_id => 'Debian_64',
   :iso_file => "debian-wheezy-DI-rc1-amd64-netinst.iso",
   :iso_src => "http://cdimage.debian.org/cdimage/wheezy_di_rc1/amd64/iso-cd/debian-wheezy-DI-rc1-amd64-netinst.iso",

--- a/definitions/debian-70rc1-x64-vf503/definition.rb
+++ b/definitions/debian-70rc1-x64-vf503/definition.rb
@@ -3,7 +3,7 @@
 Veewee::Definition.declare({
   :cpu_count => '1',
   :memory_size=> '256',
-  :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off',
+  :disk_size => '81920', :disk_format => 'VDI', :hostiocache => 'off',
   :os_type_id => 'Debian_64',
   :iso_file => "debian-wheezy-DI-rc1-amd64-netinst.iso",
   :iso_src => "http://cdimage.debian.org/cdimage/wheezy_di_rc1/amd64/iso-cd/debian-wheezy-DI-rc1-amd64-netinst.iso",

--- a/definitions/fedora-18-x64-vbox4210-nocm/definition.rb
+++ b/definitions/fedora-18-x64-vbox4210-nocm/definition.rb
@@ -1,7 +1,7 @@
 Veewee::Session.declare({
   # Minimum RAM requirement for installation is 512MB.
   :cpu_count => '1', :memory_size=> '512',
-  :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off', :hwvirtext => 'on',
+  :disk_size => '81920', :disk_format => 'VDI', :hostiocache => 'off', :hwvirtext => 'on',
   :os_type_id => 'Fedora_64',
   :iso_file => "Fedora-18-x86_64-DVD.iso",
   :iso_src => "http://mirrors.kernel.org/fedora/releases/18/Fedora/x86_64/iso/Fedora-18-x86_64-DVD.iso",

--- a/definitions/fedora-18-x64-vbox4210/definition.rb
+++ b/definitions/fedora-18-x64-vbox4210/definition.rb
@@ -1,7 +1,7 @@
 Veewee::Session.declare({
   # Minimum RAM requirement for installation is 512MB.
   :cpu_count => '1', :memory_size=> '512',
-  :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off', :hwvirtext => 'on',
+  :disk_size => '81920', :disk_format => 'VDI', :hostiocache => 'off', :hwvirtext => 'on',
   :os_type_id => 'Fedora_64',
   :iso_file => "Fedora-18-x86_64-DVD.iso",
   :iso_src => "http://mirrors.kernel.org/fedora/releases/18/Fedora/x86_64/iso/Fedora-18-x86_64-DVD.iso",

--- a/definitions/fedora-18-x64-vf503-nocm/definition.rb
+++ b/definitions/fedora-18-x64-vf503-nocm/definition.rb
@@ -2,7 +2,7 @@ Veewee::Session.declare({
   # Minimum RAM requirement for installation is 512MB.
   :cpu_count => '1',
   :memory_size=> '512',
-  :disk_size => '10140',
+  :disk_size => '81920',
   :disk_format => 'VDI',
   :hostiocache => 'off',
   :hwvirtext => 'on',

--- a/definitions/fedora-18-x64-vf503/definition.rb
+++ b/definitions/fedora-18-x64-vf503/definition.rb
@@ -2,7 +2,7 @@ Veewee::Session.declare({
   # Minimum RAM requirement for installation is 512MB.
   :cpu_count => '1',
   :memory_size=> '512',
-  :disk_size => '10140',
+  :disk_size => '81920',
   :disk_format => 'VDI',
   :hostiocache => 'off',
   :hwvirtext => 'on',

--- a/definitions/sles-11sp1-x64-vbox4210-nocm/definition.rb
+++ b/definitions/sles-11sp1-x64-vbox4210-nocm/definition.rb
@@ -2,7 +2,7 @@ Veewee::Session.declare({
   :os_type_id  => 'OpenSUSE_64',
   :cpu_count   => '1',
   :memory_size => '1024',
-  :disk_size   => '20480',
+  :disk_size   => '81920',
   :disk_format => 'VDI',
   :hostiocache => 'off',
   :iso_file => "SLES-11-SP1-DVD-x86_64-GM-DVD1.iso",

--- a/definitions/sles-11sp1-x64-vbox4210/definition.rb
+++ b/definitions/sles-11sp1-x64-vbox4210/definition.rb
@@ -2,7 +2,7 @@ Veewee::Session.declare({
   :os_type_id  => 'OpenSUSE_64',
   :cpu_count   => '1',
   :memory_size => '1024',
-  :disk_size   => '20480',
+  :disk_size   => '81920',
   :disk_format => 'VDI',
   :hostiocache => 'off',
   :iso_file => "SLES-11-SP1-DVD-x86_64-GM-DVD1.iso",

--- a/definitions/sles-11sp1-x64/definition.rb
+++ b/definitions/sles-11sp1-x64/definition.rb
@@ -2,7 +2,7 @@ Veewee::Session.declare({
   :os_type_id  => 'OpenSUSE_64',
   :cpu_count   => '1',
   :memory_size => '1024',
-  :disk_size   => '20480',
+  :disk_size   => '81920',
   :disk_format => 'VDI',
   :hostiocache => 'off',
   :iso_file => "SLES-11-SP1-DVD-x86_64-GM-DVD1.iso",

--- a/definitions/ubuntu-server-1004-x64/definition.rb
+++ b/definitions/ubuntu-server-1004-x64/definition.rb
@@ -1,6 +1,6 @@
 Veewee::Session.declare({
   :cpu_count => '1', :memory_size=> '384',
-  :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off',
+  :disk_size => '81920', :disk_format => 'VDI', :hostiocache => 'off',
   :os_type_id => 'Ubuntu',
   :iso_file => "ubuntu-10.04.4-server-amd64.iso",
   :iso_src => "http://releases.ubuntu.com/10.04.4/ubuntu-10.04.4-server-amd64.iso",

--- a/definitions/ubuntu-server-10044-x64-fusion503-nocm/definition.rb
+++ b/definitions/ubuntu-server-10044-x64-fusion503-nocm/definition.rb
@@ -1,7 +1,7 @@
 Veewee::Session.declare({
   :cpu_count => '1',
   :memory_size=> '384',
-  :disk_size => '10140',
+  :disk_size => '81920',
   :disk_format => 'VDI',
   :hostiocache => 'off',
   :os_type_id => 'Ubuntu_64',

--- a/definitions/ubuntu-server-10044-x64-fusion503/definition.rb
+++ b/definitions/ubuntu-server-10044-x64-fusion503/definition.rb
@@ -1,7 +1,7 @@
 Veewee::Session.declare({
   :cpu_count => '1',
   :memory_size=> '384',
-  :disk_size => '10140',
+  :disk_size => '81920',
   :disk_format => 'VDI',
   :hostiocache => 'off',
   :os_type_id => 'Ubuntu_64',

--- a/definitions/ubuntu-server-10044-x64-vbox4210-nocm/definition.rb
+++ b/definitions/ubuntu-server-10044-x64-vbox4210-nocm/definition.rb
@@ -1,6 +1,6 @@
 Veewee::Definition.declare({
   :cpu_count => '1', :memory_size=> '384', 
-  :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off',
+  :disk_size => '81920', :disk_format => 'VDI', :hostiocache => 'off',
   :os_type_id => 'Ubuntu_64',
   :iso_file => "ubuntu-10.04.x-server-amd64-netboot.iso",
   :iso_src => "http://archive.ubuntu.com/ubuntu/dists/lucid/main/installer-amd64/current/images/netboot/mini.iso",

--- a/definitions/ubuntu-server-10044-x64-vbox4210/definition.rb
+++ b/definitions/ubuntu-server-10044-x64-vbox4210/definition.rb
@@ -1,6 +1,6 @@
 Veewee::Definition.declare({
   :cpu_count => '1', :memory_size=> '384', 
-  :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off',
+  :disk_size => '81920', :disk_format => 'VDI', :hostiocache => 'off',
   :os_type_id => 'Ubuntu_64',
   :iso_file => "ubuntu-10.04.x-server-amd64-netboot.iso",
   :iso_src => "http://archive.ubuntu.com/ubuntu/dists/lucid/main/installer-amd64/current/images/netboot/mini.iso",

--- a/definitions/ubuntu-server-1204-x64/definition.rb
+++ b/definitions/ubuntu-server-1204-x64/definition.rb
@@ -1,7 +1,7 @@
 Veewee::Session.declare({
   :cpu_count => '1',
   :memory_size=> '2048',
-  :disk_size => '10140',
+  :disk_size => '81920',
   :disk_format => 'VDI',
   :hostiocache => 'off',
   :os_type_id => 'Ubuntu_64',

--- a/definitions/ubuntu-server-12042-x64-fusion503/definition.rb
+++ b/definitions/ubuntu-server-12042-x64-fusion503/definition.rb
@@ -1,7 +1,7 @@
 Veewee::Session.declare({
   :cpu_count => '1',
   :memory_size=> '512',
-  :disk_size => '10140',
+  :disk_size => '81920',
   :disk_format => 'VDI',
   :hostiocache => 'off',
   :os_type_id => 'Ubuntu_64',

--- a/definitions/ubuntu-server-12042-x64-vbox4210-nocm/definition.rb
+++ b/definitions/ubuntu-server-12042-x64-vbox4210-nocm/definition.rb
@@ -1,7 +1,7 @@
 Veewee::Session.declare({
   :cpu_count => '1',
   :memory_size=> '512',
-  :disk_size => '10140',
+  :disk_size => '81920',
   :disk_format => 'VDI',
   :hostiocache => 'off',
   :os_type_id => 'Ubuntu_64',

--- a/definitions/ubuntu-server-12042-x64-vbox4210/definition.rb
+++ b/definitions/ubuntu-server-12042-x64-vbox4210/definition.rb
@@ -1,7 +1,7 @@
 Veewee::Session.declare({
   :cpu_count => '1',
   :memory_size=> '512',
-  :disk_size => '10140',
+  :disk_size => '81920',
   :disk_format => 'VDI',
   :hostiocache => 'off',
   :os_type_id => 'Ubuntu_64',

--- a/definitions/ubuntu-svr-12042-x64-vf503-nocm/definition.rb
+++ b/definitions/ubuntu-svr-12042-x64-vf503-nocm/definition.rb
@@ -1,7 +1,7 @@
 Veewee::Session.declare({
   :cpu_count => '1',
   :memory_size=> '512',
-  :disk_size => '10140',
+  :disk_size => '81920',
   :disk_format => 'VDI',
   :hostiocache => 'off',
   :os_type_id => 'Ubuntu_64',


### PR DESCRIPTION
The vagrant boxes provided by files.vagrantup.com have dynamic disks sized to 80GB.

These boxes instead are only 10 GB. This makes using the boxes for testing and developing larger sites with many files difficult.

I basically just ran `sed -i "s/:disk_size => '10140'/:disk_size => '81920'/" definitions/*/definition.rb` on the files, and manually changed the sles definitions to match.

It'd be nice if all the definitions were laid out the same, but that's for another commit.
